### PR TITLE
fix issue #440

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -60,7 +60,7 @@ module.exports = async (input = 'patch', options) => {
 	const pkgManagerName = options.yarn === true ? 'Yarn' : 'npm';
 	const rootDir = pkgDir.sync();
 	const hasLockFile = fs.existsSync(path.resolve(rootDir, options.yarn ? 'yarn.lock' : 'package-lock.json')) || fs.existsSync(path.resolve(rootDir, 'npm-shrinkwrap.json'));
-	const isOnGitHub = options.repoUrl && hostedGitInfo.fromUrl(options.repoUrl).type === 'github';
+	const isOnGitHub = options.repoUrl && (hostedGitInfo.fromUrl(options.repoUrl) || {}).type === 'github';
 
 	let isPublished = false;
 


### PR DESCRIPTION
For the doc of [hosted-git-info](https://github.com/npm/hosted-git-info):

> If the URL can't be matched with a git host, null will be returned

So `hostedGitInfo.fromUrl()` may return `null`, this commit fixed the issue.

<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
